### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-syncthing [![Docker Pulls](https://img.shields.io/docker/pulls/jaecen/docker-syncthing.svg?maxAge=2592000)](https://hub.docker.com/r/jaecen/docker-syncthing)
+# docker-syncthing [![Docker Pulls](https://img.shields.io/docker/pulls/jaecen/docker-syncthing.svg?maxAge=2592000)](https://hub.docker.com/r/jaecen/docker-syncthing) [![](https://images.microbadger.com/badges/image/jaecen/docker-syncthing.svg)](https://microbadger.com/images/jaecen/docker-syncthing "Get your own image badge on microbadger.com")
 
 Run syncthing from a docker container
 
@@ -24,3 +24,4 @@ If you want to add a new folder, make sure you set the path to something in `/sr
 
 ## Developing
 You can run `run.sh` to restart the bud-ssl terminator and syncthing. Any push to this repo will auto-update the docker image on docker hub.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [jaecen/docker-syncthing](https://hub.docker.com/r/jaecen/docker-syncthing/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/jaecen/docker-syncthing).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/jaecen/docker-syncthing.svg)](https://microbadger.com/images/jaecen/docker-syncthing)
